### PR TITLE
Fix deprecation warnings in BinPacker

### DIFF
--- a/src/BinPacker.php
+++ b/src/BinPacker.php
@@ -144,7 +144,7 @@ class BinPacker
     private function sort($blocks)
     {
         usort($blocks, function (Block $a, Block $b) {
-            return $a->getHeight() < $b->getHeight() -1 : ($a->getHeight() === $b->getHeight() ? 0 : 1);
+            return $a->getHeight() < $b->getHeight() ? -1 : ($a->getHeight() === $b->getHeight() ? 0 : 1);
         });
 
         return $blocks;

--- a/src/BinPacker.php
+++ b/src/BinPacker.php
@@ -144,7 +144,7 @@ class BinPacker
     private function sort($blocks)
     {
         usort($blocks, function (Block $a, Block $b) {
-            return $a->getHeight() < $b->getHeight() ;
+            return $a->getHeight() < $b->getHeight() -1 : ($a->getHeight() === $b->getHeight() ? 0 : 1);
         });
 
         return $blocks;


### PR DESCRIPTION
Use int return values in comparison function to fix deprecation warnings (appearing in PHP 8.1.8).